### PR TITLE
Implement error handling and diagnostics

### DIFF
--- a/bin/soy
+++ b/bin/soy
@@ -12,6 +12,12 @@ foreach ($autoloaders as $autoloader) {
 
 $recipe = require_once 'recipe.php';
 
+if (!$recipe instanceof \Soy\Recipe) {
+    \Soy\Exception\Diagnoser::diagnose(new \Soy\Exception\NoRecipeReturnedException(
+        'No recipe returned in file ' . realpath('recipe.php')
+    ));
+}
+
 $soy = new \Soy\Soy($recipe);
 
 $cli = new \Soy\Cli($soy);

--- a/src/Soy/Exception/Diagnoser.php
+++ b/src/Soy/Exception/Diagnoser.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Soy\Exception;
+
+use Exception;
+use League\CLImate\CLImate;
+use ReflectionException;
+
+class Diagnoser
+{
+    const MESSAGE_DEFINE_COMPONENT = <<<'PHP'
+<?php
+
+$recipe->component('%s', function () {
+    // ...
+});
+PHP;
+
+    const MESSAGE_FORGOT_DEFAULT = <<<'PHP'
+<?php
+
+$recipe->component('default', null, ['my-component-1', 'my-component-2']);
+PHP;
+
+    const MESSAGE_CALL_DIFFERENT = '$ soy my-component';
+
+    const MESSAGE_PREPARE_RETURN = <<<'PHP'
+<?php
+
+$recipe->prepare(%1$s::class, function(%1$s $task) {
+    <underline>return</underline> $task->setFoo('bar');
+});
+PHP;
+
+    const MESSAGE_RETURN_RECIPE = <<<'PHP'
+<?php
+
+$recipe = new Soy\Recipe();
+
+// ...
+
+return $recipe;
+PHP;
+
+    /**
+     * @param Exception $exception
+     */
+    public static function diagnose(Exception $exception)
+    {
+        $climate = new CLImate();
+        
+        $climate->error(get_class($exception) . ': ' . $exception->getMessage());
+        $climate->error($exception->getTraceAsString())->br();
+
+        if ($exception instanceof UnknownComponentException) {
+            if ($exception->getComponent() === 'default') {
+                $climate->lightYellow('Did you forget the default component?');
+                $climate->dim(self::MESSAGE_FORGOT_DEFAULT)->br();
+            }
+
+            $climate->lightYellow('Did you forget to define the component?');
+            $climate->dim(sprintf(self::MESSAGE_DEFINE_COMPONENT, $exception->getComponent()))->br();
+
+            $climate->lightYellow('Did you mean to call a different component?');
+            $climate->dim(self::MESSAGE_CALL_DIFFERENT)->br();
+        } elseif ($exception instanceof ReflectionException) {
+            if (preg_match('/^Class .*Task does not exist$/', $exception->getMessage())) {
+                $climate->lightYellow('Did you forget to include the task with composer?');
+                $climate->dim('$ composer require vendor/my-task')->br();
+            }
+        } elseif ($exception instanceof FatalErrorException) {
+            if (preg_match(
+                '/^Argument \d+ passed to {closure}\(\) must be an instance of (.*), null given/',
+                $exception->getMessage(),
+                $matches
+            )) {
+                $climate->lightYellow('Did you forget to return the object in your preparation?');
+                $climate->dim(sprintf(self::MESSAGE_PREPARE_RETURN, $matches[1]))->br();
+            }
+        } elseif ($exception instanceof NoRecipeReturnedException) {
+            $climate->lightYellow('Did you forget to return the recipe object in your recipe.php?');
+            $climate->dim(self::MESSAGE_RETURN_RECIPE)->br();
+        }
+
+        die;
+    }
+}

--- a/src/Soy/Exception/FatalErrorException.php
+++ b/src/Soy/Exception/FatalErrorException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Soy\Exception;
+
+class FatalErrorException extends \Exception
+{
+}

--- a/src/Soy/Exception/NoRecipeReturnedException.php
+++ b/src/Soy/Exception/NoRecipeReturnedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Soy\Exception;
+
+class NoRecipeReturnedException extends \Exception
+{
+}

--- a/src/Soy/Exception/UnknownComponentException.php
+++ b/src/Soy/Exception/UnknownComponentException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Soy\Exception;
+
+class UnknownComponentException extends \Exception
+{
+    /**
+     * @var string
+     */
+    protected $component;
+
+    /**
+     * @param string $message
+     * @param string $component
+     */
+    public function __construct($message, $component = null)
+    {
+        parent::__construct($message);
+        $this->component = $component;
+    }
+
+    /**
+     * @return string
+     */
+    public function getComponent()
+    {
+        return $this->component;
+    }
+}

--- a/src/Soy/Soy.php
+++ b/src/Soy/Soy.php
@@ -4,9 +4,12 @@ namespace Soy;
 
 use DI\Container;
 use DI\ContainerBuilder;
+use Soy\Exception\UnknownComponentException;
 
 class Soy
 {
+    const VERSION = '0.1.0';
+
     /**
      * @var Container
      */
@@ -27,17 +30,25 @@ class Soy
 
     /**
      * @param string $component
+     * @throws UnknownComponentException
      */
     public function execute($component = 'default')
     {
         $container = $this->getContainer();
 
-        $dependencies = $this->recipe->getDependencies()[$component];
-        foreach ($dependencies as $dependency) {
+        $components = $this->recipe->getComponents();
+        $dependencies = $this->recipe->getDependencies();
+
+        if (!array_key_exists($component, $components)) {
+            throw new UnknownComponentException('Unknown component: ' . $component, $component);
+        }
+
+        $componentDependencies = $dependencies[$component];
+        foreach ($componentDependencies as $dependency) {
             $this->execute($dependency);
         }
 
-        $callable = $this->recipe->getComponents()[$component];
+        $callable = $components[$component];
         if (is_callable($callable)) {
             $container->call($callable);
         }


### PR DESCRIPTION
With this PR we're implementing proper error handling and a feature called diagnostics.
This is more of an experiment to see if the concept of diagnostics works. The nice thing is that the diagnostics is an addition onto the code base rather than being interwoven.

If this proves to be annoying or more wrong than right then we will remove it.

<img width="800" alt="screen shot 2015-11-16 at 21 23 48" src="https://cloud.githubusercontent.com/assets/1918518/11193914/8511083a-8ca9-11e5-98de-2af93522549e.png">
<img width="1257" alt="screen shot 2015-11-16 at 21 24 18" src="https://cloud.githubusercontent.com/assets/1918518/11193913/850c919c-8ca9-11e5-8ebb-c68553d25e6c.png">
