### PR TITLE
Add recipe path flag

### DIFF
--- a/bin/soy
+++ b/bin/soy
@@ -10,15 +10,5 @@ foreach ($autoloaders as $autoloader) {
     }
 }
 
-$recipe = require_once 'recipe.php';
-
-if (!$recipe instanceof \Soy\Recipe) {
-    \Soy\Exception\Diagnoser::diagnose(new \Soy\Exception\NoRecipeReturnedException(
-        'No recipe returned in file ' . realpath('recipe.php')
-    ));
-}
-
-$soy = new \Soy\Soy($recipe);
-
-$cli = new \Soy\Cli($soy);
+$cli = new \Soy\Cli();
 $cli->handle($argv);

--- a/src/Soy/Exception/Diagnoser.php
+++ b/src/Soy/Exception/Diagnoser.php
@@ -5,6 +5,7 @@ namespace Soy\Exception;
 use Exception;
 use League\CLImate\CLImate;
 use ReflectionException;
+use Soy\Cli;
 
 class Diagnoser
 {
@@ -22,7 +23,7 @@ PHP;
 $recipe->component('default', null, ['my-component-1', 'my-component-2']);
 PHP;
 
-    const MESSAGE_CALL_DIFFERENT = '$ soy my-component';
+    const MESSAGE_CALL_DIFFERENT_COMPONENT = '$ soy my-component';
 
     const MESSAGE_PREPARE_RETURN = <<<'PHP'
 <?php
@@ -40,6 +41,15 @@ $recipe = new Soy\Recipe();
 // ...
 
 return $recipe;
+PHP;
+
+    const MESSAGE_CHANGE_DIRECTORY = <<<'PHP'
+$ cd /srv/http/my-project
+$ soy
+PHP;
+
+    const MESSAGE_SPECIFY_RECIPE = <<<'PHP'
+$ soy --recipe=recipes/main.php
 PHP;
 
     /**
@@ -62,7 +72,7 @@ PHP;
             $climate->dim(sprintf(self::MESSAGE_DEFINE_COMPONENT, $exception->getComponent()))->br();
 
             $climate->lightYellow('Did you mean to call a different component?');
-            $climate->dim(self::MESSAGE_CALL_DIFFERENT)->br();
+            $climate->dim(self::MESSAGE_CALL_DIFFERENT_COMPONENT)->br();
         } elseif ($exception instanceof ReflectionException) {
             if (preg_match('/^Class .*Task does not exist$/', $exception->getMessage())) {
                 $climate->lightYellow('Did you forget to include the task with composer?');
@@ -80,6 +90,17 @@ PHP;
         } elseif ($exception instanceof NoRecipeReturnedException) {
             $climate->lightYellow('Did you forget to return the recipe object in your recipe.php?');
             $climate->dim(self::MESSAGE_RETURN_RECIPE)->br();
+        } elseif ($exception instanceof RecipeFileNotFoundException) {
+            if ($exception->getRecipeFile() === Cli::DEFAULT_RECIPE_FILE) {
+                $climate->lightYellow('Change to the right directory containing the recipe.php');
+                $climate->dim(self::MESSAGE_CHANGE_DIRECTORY)->br();
+
+                $climate->lightYellow('Execute soy with --recipe to define the location of the recipe.php');
+                $climate->dim(self::MESSAGE_SPECIFY_RECIPE)->br();
+            } else {
+                $climate->lightYellow('This file doesn\'t seem to exist or isn\'t accessible:');
+                $climate->dim($exception->getRecipeFile())->br();
+            }
         }
 
         exit(255);

--- a/src/Soy/Exception/RecipeFileNotFoundException.php
+++ b/src/Soy/Exception/RecipeFileNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Soy\Exception;
+
+class RecipeFileNotFoundException extends \Exception
+{
+    /**
+     * @var string
+     */
+    private $recipeFile;
+
+    /**
+     * @param string $message
+     * @param string $recipeFile
+     */
+    public function __construct($message, $recipeFile)
+    {
+        parent::__construct($message);
+        $this->recipeFile = $recipeFile;
+    }
+
+    /**
+     * @return string
+     */
+    public function getRecipeFile()
+    {
+        return $this->recipeFile;
+    }
+}


### PR DESCRIPTION
Moving the `recipe.php` later on into the process and using a temporary climate instance to parse arguments before including the `recipe.php` in order to improve user experience in the early stage.
