### PR TITLE
Fix for the current directory for recipes

### DIFF
--- a/src/Soy/Cli.php
+++ b/src/Soy/Cli.php
@@ -121,7 +121,7 @@ class Cli
 
         chdir(dirname($recipeFile));
 
-        $recipe = include_once $recipeFile;
+        $recipe = include_once basename($recipeFile);
 
         if (!$recipe instanceof Recipe) {
             throw new NoRecipeReturnedException('No recipe returned in file ' . realpath($recipeFile));


### PR DESCRIPTION
The working directory was based on the recipe path, so when including it should use just the recipe basename
