### PR TITLE
Introduce namespaced commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,65 @@ $recipe->component('gulp', function (\Soy\Task\GulpTask $gulpTask, \League\CLIma
 
 You can put anything in the signature of the closure, the corresponding objects will be injected based on the type-hint.
 
+### CLI
+There are three ways of defining CLI commands, each suitable for different situations.
+
+If you want to introduce a global argument:
+
+```php
+$recipe->cli(function (\League\CLImate\CLImate $climate) {
+    $climate->arguments->add([
+        'foo' => [
+            'description' => 'foo',
+            'longPrefix' => 'foo',
+            'noValue' => true,
+        ],
+    ]);
+});
+```
+
+If you want to add arguments from a specific task to your CLI:
+
+```php
+$fooComponent = $recipe->component('foo', function (\Soy\Task\FooTask $fooTask, \Soy\Task\BarTask $barTask) {
+    $fooTask->run();
+    $barTask->run();
+});
+
+$fooComponent->cli([\Soy\Task\FooTask::class, 'prepareCli']);
+$fooComponent->cli([\Soy\Task\BarTask::class, 'prepareCli']);
+```
+
+You can also use fluent interfacing:
+
+```php
+$recipe->component('foo', function (\Soy\Task\FooTask $fooTask, \Soy\Task\BarTask $barTask) {
+    $fooTask->run();
+    $barTask->run();
+})
+    ->cli([\Soy\Task\FooTask::class, 'prepareCli'])
+    ->cli([\Soy\Task\BarTask::class, 'prepareCli'])
+;
+```
+
+If you want to add your own component specific arguments:
+
+```php
+$fooComponent = $recipe->component('foo', function (\Soy\Task\FooTask $fooTask) {
+    $fooTask->run();
+});
+
+$fooComponent->cli(function (\League\CLImate\CLImate $climate) {
+    $climate->arguments->add([
+        'foo' => [
+            'description' => 'foo',
+            'longPrefix' => 'foo',
+            'noValue' => true,
+        ],
+    ]);
+});
+```
+
 ## Why Soy?
 Soy's focus is to give power back to the developer.
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ $recipe->cli(function (\League\CLImate\CLImate $climate) {
 });
 ```
 
-If you want to add arguments from a specific task to your CLI:
+If you want to add arguments from a specific task to your component:
 
 ```php
 $fooComponent = $recipe->component('foo', function (\Soy\Task\FooTask $fooTask, \Soy\Task\BarTask $barTask) {

--- a/bin/soy
+++ b/bin/soy
@@ -11,4 +11,4 @@ foreach ($autoloaders as $autoloader) {
 }
 
 $cli = new \Soy\Cli();
-$cli->handle($argv);
+$cli->handle();

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   ],
   "extra": {
     "branch-alias": {
-      "dev-develop": "0.1.x-dev"
+      "dev-develop": "0.2.x-dev"
     }
   }
 }

--- a/src/Soy/Cli.php
+++ b/src/Soy/Cli.php
@@ -130,6 +130,9 @@ class Cli
         return new Soy($recipe);
     }
 
+    /**
+     * @param CLImate $climate
+     */
     private function validateCli(CLImate $climate)
     {
         $longPrefixes = [];

--- a/src/Soy/Component.php
+++ b/src/Soy/Component.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Soy;
+
+use DI\Container;
+use League\CLImate\CLImate;
+
+class Component
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @var array
+     */
+    private $cliPreparations = [];
+
+    /**
+     * @param string $name
+     * @param callable $callable
+     */
+    public function __construct($name, $callable)
+    {
+        $this->name = $name;
+        $this->callable = $callable;
+    }
+
+    /**
+     * @param callable $callable
+     * @return $this
+     */
+    public function cli(callable $callable)
+    {
+        $this->cliPreparations[] = $callable;
+        return $this;
+    }
+
+    /**
+     * @return callable[]
+     */
+    public function getCliPreparations()
+    {
+        return $this->cliPreparations;
+    }
+
+    /**
+     * @param Container $container
+     * @return callable
+     */
+    public function execute(Container $container)
+    {
+        $container->call($this->callable);
+    }
+
+    /**
+     * @param CLImate $climate
+     */
+    public function prepareCli(CLImate $climate)
+    {
+        $cliPreparations = $this->getCliPreparations();
+        foreach ($cliPreparations as $cliPreparation) {
+            $cliPreparation($climate);
+        }
+    }
+}

--- a/src/Soy/Exception/CliArgumentDuplicationException.php
+++ b/src/Soy/Exception/CliArgumentDuplicationException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Soy\Exception;
+
+class CliArgumentDuplicationException extends \LogicException
+{
+}

--- a/src/Soy/Recipe.php
+++ b/src/Soy/Recipe.php
@@ -2,6 +2,7 @@
 
 namespace Soy;
 
+use League\CLImate\CLImate;
 use Soy\Exception\UnknownComponentException;
 
 class Recipe
@@ -89,5 +90,16 @@ class Recipe
     public function getDependencies()
     {
         return $this->dependencies;
+    }
+
+    /**
+     * @param callable $callable
+     */
+    public function cli(callable $callable)
+    {
+        $this->prepare(CLImate::class, function (CLImate $climate) use ($callable) {
+            $callable($climate);
+            return $climate;
+        });
     }
 }

--- a/src/Soy/Recipe.php
+++ b/src/Soy/Recipe.php
@@ -94,6 +94,7 @@ class Recipe
 
     /**
      * @param callable $callable
+     * @return $this
      */
     public function cli(callable $callable)
     {
@@ -101,5 +102,7 @@ class Recipe
             $callable($climate);
             return $climate;
         });
+
+        return $this;
     }
 }

--- a/src/Soy/Recipe.php
+++ b/src/Soy/Recipe.php
@@ -2,6 +2,8 @@
 
 namespace Soy;
 
+use Soy\Exception\UnknownComponentException;
+
 class Recipe
 {
     /**
@@ -10,7 +12,7 @@ class Recipe
     private $preparations = [];
 
     /**
-     * @var array
+     * @var Component[]
      */
     private $components = [];
 
@@ -41,19 +43,36 @@ class Recipe
      * @param string $component
      * @param callable|null $callable
      * @param array $dependencies
+     * @return Component
      */
     public function component($component, callable $callable = null, array $dependencies = [])
     {
-        $this->components[$component] = $callable;
+        $this->components[$component] = new Component($component, $callable);
         $this->dependencies[$component] = $dependencies;
+
+        return $this->components[$component];
     }
 
     /**
-     * @return array
+     * @return Component[]
      */
     public function getComponents()
     {
         return $this->components;
+    }
+
+    /**
+     * @param string $componentName
+     * @return Component
+     * @throws UnknownComponentException
+     */
+    public function getComponent($componentName)
+    {
+        if (!array_key_exists($componentName, $this->components)) {
+            throw new UnknownComponentException('Component ' . $componentName . ' not found');
+        }
+
+        return $this->components[$componentName];
     }
 
     /**


### PR DESCRIPTION
There are now three ways of defining cli commands, each suitable for different situations.

If you want to introduce a global argument:

``` php
$recipe->cli(function (\League\CLImate\CLImate $climate) {
    $climate->arguments->add([
        'foo' => [
            'description' => 'foo',
            'longPrefix' => 'foo',
            'noValue' => true,
        ],
    ]);
});
```

If you want to add arguments from a specific task to your command line:

``` php
$fooComponent = $recipe->component('foo', function (\Soy\Task\FooTask $fooTask, \Soy\Task\BarTask $barTask) {
    $fooTask->run();
    $barTask->run();
});

$fooComponent->cli([\Soy\Task\FooTask::class, 'prepareCli']);
$fooComponent->cli([\Soy\Task\BarTask::class, 'prepareCli']);
```

If you want to add your own component specific arguments:

``` php
$fooComponent = $recipe->component('foo', function (\Soy\Task\FooTask $fooTask) {
    $fooTask->run();
});

$fooComponent->cli(function (\League\CLImate\CLImate $climate) {
    $climate->arguments->add([
        'foo' => [
            'description' => 'foo',
            'longPrefix' => 'foo',
            'noValue' => true,
        ],
    ]);
});
```
