### PR TITLE
Ignore component name that starts with dash

### DIFF
--- a/src/Soy/Cli.php
+++ b/src/Soy/Cli.php
@@ -63,9 +63,9 @@ class Cli
         $climate = $container->get(CLImate::class);
         $climate->arguments->parse();
 
-        $componentName = $climate->arguments->get('component');
+        $componentName = $this->parseComponentFromCli($climate);
 
-        $soy->prepareCli($climate);
+        $soy->prepareCli($climate, $componentName);
         $this->validateCli($climate);
 
         if ($climate->arguments->defined('help')) {
@@ -137,15 +137,9 @@ class Cli
     {
         $longPrefixes = [];
         $prefixes = [];
-        $names = [];
 
         $arguments = $climate->arguments->all();
         foreach ($arguments as $argument) {
-            if (in_array($argument->name(), $names)) {
-                throw new CliArgumentDuplicationException('Duplicate name: ' . $argument->name());
-            }
-            $names[] = $argument->name();
-
             if (in_array($argument->longPrefix(), $longPrefixes)) {
                 throw new CliArgumentDuplicationException('Duplicate longPrefix: ' . $argument->longPrefix());
             }
@@ -156,5 +150,20 @@ class Cli
             }
             $prefixes[] = $argument->prefix();
         }
+    }
+
+    /**
+     * @param CLImate $climate
+     * @return string
+     */
+    private function parseComponentFromCli(CLImate $climate)
+    {
+        $componentName = $climate->arguments->get('component');
+
+        if (strpos($componentName, '-') === 0) {
+            $componentName = $climate->arguments->all()['component']->defaultValue();
+        }
+
+        return $componentName;
     }
 }

--- a/src/Soy/Exception/Diagnoser.php
+++ b/src/Soy/Exception/Diagnoser.php
@@ -52,6 +52,10 @@ PHP;
 $ soy --recipe recipes/main.php
 PHP;
 
+    const MESSAGE_FLAG_WITHOUT_VALUE = <<<'PHP'
+$ soy --foo my-value
+PHP;
+
     /**
      * @param Exception $exception
      */
@@ -86,6 +90,13 @@ PHP;
             )) {
                 $climate->lightYellow('Did you forget to return the object in your preparation?');
                 $climate->dim(sprintf(self::MESSAGE_PREPARE_RETURN, $matches[1]))->br();
+            } elseif (preg_match(
+                '/Undefined offset: 1 in (.*Parser\.php.*) on line \d+/',
+                $exception->getMessage(),
+                $matches
+            )) {
+                $climate->lightYellow('Did you use an argument, that expects a value, without a value?');
+                $climate->dim(self::MESSAGE_FLAG_WITHOUT_VALUE)->br();
             }
         } elseif ($exception instanceof NoRecipeReturnedException) {
             $climate->lightYellow('Did you forget to return the recipe object in your recipe.php?');

--- a/src/Soy/Soy.php
+++ b/src/Soy/Soy.php
@@ -37,19 +37,11 @@ class Soy
     {
         $container = $this->getContainer();
 
-        $components = $this->recipe->getComponents();
-
         $this->traverseDependencies($componentName, function ($dependency) {
             $this->execute($dependency);
         });
 
-        if (!array_key_exists($componentName, $components)) {
-            throw new UnknownComponentException('Unknown component: ' . $componentName, $componentName);
-        }
-
-
-        $component = $components[$componentName];
-        $component->execute($container);
+        $this->getRecipe()->getComponent($componentName)->execute($container);
     }
 
     public function prepare()
@@ -89,16 +81,18 @@ class Soy
 
     /**
      * @param CLImate $climate
+     * @param string $componentName
+     * @throws UnknownComponentException
      */
-    public function prepareCli(CLImate $climate)
+    public function prepareCli(CLImate $climate, $componentName)
     {
-        $componentName = $climate->arguments->get('component');
+        $component = $this->getRecipe()->getComponent($componentName);
 
         $this->traverseDependencies($componentName, function ($componentName) use ($climate) {
             $this->getRecipe()->getComponent($componentName)->prepareCli($climate);
         });
 
-        $this->getRecipe()->getComponent($componentName)->prepareCli($climate);
+        $component->prepareCli($climate);
 
         $climate->arguments->parse();
     }


### PR DESCRIPTION
No more issues when using:

``` sh
$ soy --foo bar
```

This will now fallback to `default` component
